### PR TITLE
fix: reduce path to be relative to current directory

### DIFF
--- a/lua/composer.lua
+++ b/lua/composer.lua
@@ -27,7 +27,7 @@ function composer.resolve_php_namespace()
     return nil
   end
 
-  local buffer_directory = vim.fn.expand("%:h")
+  local buffer_directory = vim.fn.expand("%:.:h")
   local autoload = composer_data["autoload"]
 
   if autoload["psr-4"] ~= nil then


### PR DESCRIPTION
First off, thank you for the neat plugin! It's been helping a ton.

When creating files from nvim-tree or oil.nvim usually the `expand("%:h")` results in `~/path/to/php_project/` instead of just `php_project/`. This PR fixes just that